### PR TITLE
Rudimentary CI for macOS, iOS and android targets

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      # Check for updates to GitHub Actions every weekday
+      interval: daily
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - version-update:semver-patch
+  # Maintain dependencies for Cargo
+  - # ignore patch updates
+    package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: daily
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - version-update:semver-patch

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,36 @@
+name: CI
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  ios:
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          targets: aarch64-apple-ios-sim,aarch64-apple-ios,x86_64-apple-ios
+      - name: build
+        run: cargo build --target aarch64-apple-ios-sim --target aarch64-apple-ios --target x86_64-apple-ios
+  macos:
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          targets: aarch64-apple-darwin,x86_64-apple-darwin
+      - name: build
+        run: cargo build --target aarch64-apple-ios-sim --target aarch64-apple-ios --target x86_64-apple-ios
+  android:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          targets: x86_64-linux-android,x86_64-linux-android
+      - name: build
+        run: cargo build --target aarch64-apple-ios-sim --target aarch64-apple-ios --target x86_64-apple-ios

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 /target
 /old
-.*
 
 # local development
 /design.md


### PR DESCRIPTION
At this stage in a project, I think just CI should build for iOS, macOS and android is burdensome enough. I added dependabot because it's just pretty nice for knowing which dependency upgrades require actual work and which do not.

I ran the android builds locally (on a linux machine) and it does break. If you want, I can break that into a separate PR with some android parts stubbed.

Protip, running [`actionlint`](https://github.com/rhysd/actionlint) on this stuff prevents a lot of CI headache.